### PR TITLE
Added dst (delete surrounding tag) and cst (change surrounding tag).

### DIFF
--- a/action_cmds.py
+++ b/action_cmds.py
@@ -138,9 +138,15 @@ class _vi_plug_c_s(sublime_plugin.TextCommand):
         open_, close_ = _vi_plug_c_s.PAIRS.get(old, (old, old))
         new_open, new_close = _vi_plug_c_s.PAIRS.get(new, (new, new))
 
-        # brute force
-        next_ = self.view.find(close_, s.b, sublime.LITERAL)
-        prev_ = reverse_search(self.view, open_, end=s.b, start=0, flags=sublime.LITERAL)
+        if len(open_) == 1 and open_ == 't':
+            open_, close_ = ('<.*?>', '</.*?>')
+            next_ = self.view.find(close_, s.b)
+            prev_ = reverse_search(self.view, open_, end=s.b, start=0)
+        else:
+            # brute force
+            next_ = self.view.find(close_, s.b, sublime.LITERAL)
+            prev_ = reverse_search(self.view, open_, end=s.b, start=0, flags=sublime.LITERAL)
+        
         if not (next_ and prev_):
             return
 
@@ -171,9 +177,15 @@ class _vi_plug_d_s(sublime_plugin.TextCommand):
         old, new = (replace_what, '')
         open_, close_ = _vi_plug_c_s.PAIRS.get(old, (old, old))
 
-        # brute force
-        next_ = self.view.find(close_, s.b, sublime.LITERAL)
-        prev_ = reverse_search(self.view, open_, end=s.b, start=0, flags=sublime.LITERAL)
+        if len(open_) == 1 and open_ == 't':
+            open_, close_ = ('<.*?>', '</.*?>')
+            next_ = self.view.find(close_, s.b)
+            prev_ = reverse_search(self.view, open_, end=s.b, start=0)
+        else:
+            # brute force
+            next_ = self.view.find(close_, s.b, sublime.LITERAL)
+            prev_ = reverse_search(self.view, open_, end=s.b, start=0, flags=sublime.LITERAL)
+        
         if not (next_ and prev_):
             return
 


### PR DESCRIPTION
Not sure if this is useful more generally, but I grabbed this from Evil Surround. 

dst and cst operate on a "tag", so that given:

<p>something{cursor}</p>


and dst deletes the tags and cst' changes the tags to a single quote, etc. This makes it easier to muck around with html without having to type out the entire tag each time, since it can be inferred in these cases.
